### PR TITLE
Do not generate static boost libs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -167,9 +167,6 @@
 		<delete includeemptydirs="true" failonerror="false">
 			<!-- do not delete rapidjson because this lib is not downloaded -->
 			<fileset dir="${ext.dir}" excludes="${rapidjson.str}/*"/>
-			<fileset dir="${lib.dir}">
-			   <include name="*.a"/>
-			</fileset>
 		</delete>
 	</target>
 
@@ -185,11 +182,12 @@
 			<arg value="cat /proc/cpuinfo | grep processor | wc -l"/>
 		</exec>
 		<exec executable="./b2" dir="${ext.dir}/boost-install-files/boost_${boost.version.name}" failonerror="true">
-			<arg value="--no-cmake-config"/>
+			<arg value="--no-cmake-config"/> <!-- do not create a cmake directory in the lib dir -->
 			<arg value="--with-chrono"/>
 			<arg value="--with-random"/>
 			<arg value="--with-system"/>
 			<arg value="-j${no.cpus}"/>
+			<arg value="link=shared"/> <!-- do not output static libraries -->
 			<arg value="install"/>
 		</exec>
 		<echo>Copying ${rapidjson.str} ${rapidjson.version}</echo>

--- a/samples/stt_results_http_receiver/Makefile
+++ b/samples/stt_results_http_receiver/Makefile
@@ -4,7 +4,7 @@
 
 # You must ensure that the following line points to your 
 # correct streamsx.websocket toolkit directory that is of v1.0.6 or above.
-STREAMS_WEBSOCKET_SERVER_TOOLKIT ?= $(HOME)/com.ibm.streamsx.websocket
+STREAMS_WEBSOCKET_TOOLKIT ?= $(HOME)/com.ibm.streamsx.websocket
 
 ifeq ($(STREAMS_STUDIO_BUILDING), 1)
     $(info Building from Streams Studio, use env vars set by studio)
@@ -20,7 +20,7 @@ else
     SPLC = $(STREAMS_INSTALL)/bin/sc
     DATA_DIR = data
     OUTPUT_DIR = output
-    TOOLKIT_PATH = $(STREAMS_WEBSOCKET_SERVER_TOOLKIT)
+    TOOLKIT_PATH = $(STREAMS_WEBSOCKET_TOOLKIT)
 endif
 
 SPL_MAIN_COMPOSITE = com.ibm.streamsx.sttgateway.sample.httpreceiver::STTResultsHTTPReceiver

--- a/tests/frameworktests/tests/StreamsxSttgateway/SamplesCompile/TestCase.sh
+++ b/tests/frameworktests/tests/StreamsxSttgateway/SamplesCompile/TestCase.sh
@@ -29,11 +29,11 @@ if [[ $TTRO_variantCase == 'VoiceGatewayToStreamsToWatsonS2T' ]]; then
 		setSkip "sample requires TTPR_StreamsxSpeech2TextToolkit and TTPR_StreamsxNetworkToolkit"
 	fi
 fi
-if [[ $TTRO_variantCase == 'stt_results_http_receiver' ]]; then
-	if ! isExistingAndTrue TTPR_streamsxInetserverToolkit; then
-		setSkip "sample requires TTPR_streamsxInetserverToolkit"
+if [[ $TTRO_variantCase == 'VoiceGatewayToStreamsToWatsonSTT' || $TTRO_variantCase == 'stt_results_http_receiver' || $TTRO_variantCase == 'VoiceGatewayToStreamsToWatsonS2T' ]]; then
+	if isExistingAndTrue TTPR_StreamsxWebsocketToolkit; then
+		export STREAMS_WEBSOCKET_TOOLKIT="$TTPR_StreamsxWebsocketToolkit"
 	else
-		export STREAMS_INET_SERVER_TOOLKIT="$TTPR_streamsxInetserverToolkit"
+		setSkip "sample requires TTPR_StreamsxWebsocketToolkit"
 	fi
 fi
 

--- a/tests/frameworktests/tests/TestProperties.sh
+++ b/tests/frameworktests/tests/TestProperties.sh
@@ -18,3 +18,7 @@ setVar 'TTPR_SpeechToTextUrl' "wss://api.us-south.speech-to-text.watson.cloud.ib
 setVar 'TTPR_SpeechToTextApikeyFile' "${TTRO_inputDir}/apikey.enc"
 # or you provide the environment SPEECH_TO_TEXT_APIKEY
 # or you provide the command line parameter -D TTPR_SpeechToTextApikey=<apikey>
+
+# Set the new introduced dependency to websocket toolkit
+# you may overwrite this in a myProperties.sh file
+setVar 'TTPR_StreamsxWebsocketToolkit' "$HOME/workspace/com.ibm.streamsx.websocket"


### PR DESCRIPTION
Deleting of the static libraries in ant target 'download-clean' is not the right place. The download-clean target should revert all results of the download... targets.

Deleting of generated artifacts has also a negative impact on a incremental build. Then the deleted artifacts are re-build all the time.
Not to generate not required files is the better joice